### PR TITLE
adding repositories.xml to make use with layman easier

### DIFF
--- a/repositories.xml
+++ b/repositories.xml
@@ -1,0 +1,11 @@
+<repositories encoding="unicode" version="1.1">
+  <repo priority="50" quality="experimental">
+    <name>arduino-overlay</name>
+    <description>Arduino IDE overlay for genott linux.</description>
+    <owner>
+      <email>mapmot@githun.com</email>
+      <name>mapmot</name>
+    </owner>
+    <source type="git">https://github.com/mapmot/arduino-overlay.git</source>
+  </repo>
+</repositories>


### PR DESCRIPTION
so that you can follow the layman wiki and it matches the example, no need to manually change confs
```
layman -o https://raw.github.com/mapmot/arduino-overlay/master/repositories.xml -f -a arduino-overlay
```
